### PR TITLE
Optimize GraphHelper#resources_by_date

### DIFF
--- a/lib/stat_board/graph_helper.rb
+++ b/lib/stat_board/graph_helper.rb
@@ -16,16 +16,17 @@ module StatBoard
       klass       = klass_name.to_s.constantize
       created_ats = klass.order(:created_at).pluck(:created_at).compact
       steps       = date_range.step(date_steps).map(&:end_of_day)
+      index       = 0
       counts      = created_ats.reduce(Hash.new(0)) do |counts, timestamp|
-        cutoff = steps[counts[:index]]
+        cutoff = steps[index]
 
         # As long as timestamps have not exceeded the last date step
         if cutoff.present?
           if timestamp < cutoff
             counts[cutoff] += 1
           else
-            new_index            = counts[:index] += 1
-            next_cutoff          = steps[new_index]
+            index               += 1
+            next_cutoff          = steps[index]
             counts[next_cutoff] += (counts[cutoff] + 1) if next_cutoff.present?
           end
         end
@@ -33,7 +34,6 @@ module StatBoard
         counts
       end
 
-      counts.delete(:index)
       counts.values.to_s
     end
 


### PR DESCRIPTION
## Overview
I benchmarked a handful of code chunks and determined that the `StatBoard::GraphHelper#resources_by_date` method was by far the slowest part of rendering a graph-based stat board on BabyBookie.

Some notable takeaways:
- Converting thousands of `DateTime` objects to `Date` is expensive
- Avoid re-comparing of `created_at` values
- Walk through all `created_at` values exactly once

## Pre-Optimization Benchmarks

```ruby
[1] pry(#<#<Class:0x007fca1e6cf4b8>>)> Benchmark.measure { resources_by_date('Bet') }
   (103.5ms)  SELECT "bets"."created_at" FROM "bets"
=> #<Benchmark::Tms:0x007fca0c322160 @cstime=0.0, @cutime=0.0, @label="", @real=6.659311897994485, @stime=0.07999999999999985, @total=6.460000000000001, @utime=6.380000000000001>
[2] pry(#<#<Class:0x007fca1e6cf4b8>>)> Benchmark.measure { resources_by_date('User') }
   (126.0ms)  SELECT "users"."created_at" FROM "users"
=> #<Benchmark::Tms:0x007fca0d6eb5e8 @cstime=0.0, @cutime=0.0, @label="", @real=6.971949118014891, @stime=0.07000000000000006, @total=6.720000000000001, @utime=6.65>
[3] pry(#<#<Class:0x007fca1e6cf4b8>>)> Benchmark.measure { resources_by_date('Pool') }
   (16.0ms)  SELECT "pools"."created_at" FROM "pools"
=> #<Benchmark::Tms:0x007fca26c489a0 @cstime=0.0, @cutime=0.0, @label="", @real=0.9383499419782311, @stime=0.010000000000000009, @total=0.9300000000000017, @utime=0.9200000000000017>
```

Processing 103292 bets took 6.66 seconds.
Processing 108537 users took 6.97 seconds.
Processing 14796 pools took 0.94 seconds.

Overall render time:
```
Completed 200 OK in 15043ms (Views: 14583.8ms | ActiveRecord: 457.5ms)
```


## Post-Optimization Benchmarks

```ruby
[1] pry(#<#<Class:0x007f96d694a0d8>>)> Benchmark.measure { resources_by_date('Bet') }
   (187.4ms)  SELECT "bets"."created_at" FROM "bets"  ORDER BY "bets"."created_at" ASC
=> #<Benchmark::Tms:0x007f96d8d1c998 @cstime=0.0, @cutime=0.0, @label="", @real=2.874207467015367, @stime=0.08000000000000007, @total=2.63, @utime=2.55>
[2] pry(#<#<Class:0x007f96d694a0d8>>)> Benchmark.measure { resources_by_date('User') }
   (192.6ms)  SELECT "users"."created_at" FROM "users"  ORDER BY "users"."created_at" ASC
=> #<Benchmark::Tms:0x007f96c5203cb8 @cstime=0.0, @cutime=0.0, @label="", @real=2.82556858001044, @stime=0.06999999999999984, @total=2.5499999999999994, @utime=2.4799999999999995>
[3] pry(#<#<Class:0x007f96d694a0d8>>)> Benchmark.measure { resources_by_date('Pool') }
   (21.0ms)  SELECT "pools"."created_at" FROM "pools"  ORDER BY "pools"."created_at" ASC
=> #<Benchmark::Tms:0x007f96dea38c58 @cstime=0.0, @cutime=0.0, @label="", @real=0.3504623739863746, @stime=0.0, @total=0.33000000000000007, @utime=0.33000000000000007>
```

Processing 103292 bets took 2.87 seconds.
Processing 108537 users took 2.83 seconds.
Processing 14796 pools took 0.35 seconds.

Overall render time:
```
Completed 200 OK in 7242ms (Views: 6709.9ms | ActiveRecord: 528.8ms)
```

## Conclusion
Optimizations halved render times.