### PR TITLE
Sort report classes w/ more than alphabet

### DIFF
--- a/lib/stat_board/graph_helper.rb
+++ b/lib/stat_board/graph_helper.rb
@@ -13,6 +13,7 @@ module StatBoard
       @resrouces_cache ||= {}
       @resrouces_cache[klass_name] ||= begin
         klass = klass_name.to_s.constantize
+        klass = klass.stat_board_scope if klass.respond_to?(:stat_board_scope)
         steps = date_range.step(date_steps).map(&:end_of_day)
 
         steps.map do |step_end|

--- a/lib/stat_board/reports_finder.rb
+++ b/lib/stat_board/reports_finder.rb
@@ -7,8 +7,22 @@ module StatBoard
     end
 
     def self.all
-      self.new(File.join(StatBoard::Engine.root, "lib/stat_board/reports")).report_klasses +
-      self.new(File.join(Rails.root, "lib/stat_board/reports")).report_klasses
+      all_klasses = (
+        self.new(File.join(StatBoard::Engine.root, "lib/stat_board/reports")).report_klasses +
+        self.new(File.join(Rails.root, "lib/stat_board/reports")).report_klasses
+      )
+
+      all_klasses.sort_by do |klass|
+        if klass.name.include?("::Overall")
+          1
+        elsif klass.name.include?("::Monthly")
+          2
+        elsif klass.name.include?("::Weekly")
+          3
+        else
+          4
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
👋 

By default the sort here is alphabetical, dynamically pulling "reports" from files in defined directories. So it spits out "Monthly", "Overall", "Weekly" which is confusing. This PR throws in some manual string checks to order it up right, and include additional reports after.